### PR TITLE
Add Lobby Links (Query Strings)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -270,4 +270,4 @@
     
   </script>
 </body>
-</body>
+</html>

--- a/public/lobby.js
+++ b/public/lobby.js
@@ -101,7 +101,7 @@ function initializeLobby(ruleset) {
   document.getElementById('lobbyBanDiv').append(shipBanElem);
 
   document.querySelector('#lobbyIdentifier > span').textContent = current_lobby_id;
-  document.querySelector('#lobbyIdentifier').innerHTML += '&nbsp;&nbsp;(<a href=\"/?id=' + current_lobby_id + '\" style="color: darkcyan">' + 'auto-join link</a>)';
+  document.querySelector('#lobbyIdentifier').innerHTML += '.&nbsp;&nbsp;(<a href=\"/?id=' + current_lobby_id + '\" style="color: darkcyan">' + 'auto-join link</a>)';
   // setInterval();
 
   if (user_role != -4){

--- a/public/lobby.js
+++ b/public/lobby.js
@@ -101,6 +101,7 @@ function initializeLobby(ruleset) {
   document.getElementById('lobbyBanDiv').append(shipBanElem);
 
   document.querySelector('#lobbyIdentifier > span').textContent = current_lobby_id;
+  document.querySelector('#lobbyIdentifier').innerHTML += '&nbsp;&nbsp;(<a href=\"/?id=' + current_lobby_id + '\" style="color: darkcyan">' + 'auto-join link</a>)';
   // setInterval();
 
   if (user_role != -4){

--- a/public/menu.js
+++ b/public/menu.js
@@ -101,6 +101,18 @@ function loadRuleset(){
 
 function initializeMenu() {
 
+  //Query String Handler
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(urlSearchParams.entries());
+  if (params["id"] !== undefined && params["pw"] !== undefined) { //id & pw
+    joinLobby1(params["id"], params["pw"]);
+  } else if (params["id"] !== undefined) { //id & !pw
+    const passwordInput = prompt("Please enter lobby password");
+    if (passwordInput != null) {
+      joinLobby1(params["id"], passwordInput);
+    }
+  }
+
   document.getElementById('timelineInput').value = timeline_presets[document.getElementById('timelineSelection').value].join('\n');
 
   document.getElementById('timelineSelection').addEventListener('change', event => {


### PR DESCRIPTION
### Usage
Link for lobby with identifier `077bdfa6` and password `cat` would be:
```
https://lobby.statsoficarus.xyz/?id=077bdfa6&pw=cat
```

## Changes in this PR
* Add query string parsing
* Add link of current lobby to top left (doesn't include pw - but only because I didn't see an easy way to grab that)
* Fix `index.html` closing tag